### PR TITLE
Setup building on circle-ci and publishing to bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,124 @@
+# Scala CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/sample-config/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+      
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+    
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt test:compile
+
+      - save_cache:
+          paths:
+            - "~/.sbt"
+            - "target/resolution-cache"
+            - "target/streams"
+            - "project/target/resolution-cache"
+            - "project/target/streams"
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "build.sbt" }}
+        
+      - run: sbt package
+
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory
+          root: ..
+          # Must be relative path from root
+          paths:
+            - repo
+
+  test:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+
+      - attach_workspace:
+          at: /home/circleci
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt test:test
+
+  deploy:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt publish
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - test:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - deploy:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^release-[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 project/target/
+project/project/target/
 .idea
 *.class
 *.log

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,29 @@ configs(IntegrationTest)
 Defaults.itSettings
 val TestAndIntegrationTest = "test,it"
 
-organization in ThisBuild := "com.contxt"
+organization in ThisBuild := "com.streetcontxt"
 scalaVersion in ThisBuild := "2.11.8"
-version in ThisBuild := "1.0.2-SNAPSHOT"
+licenses in ThisBuild += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+bintrayOrganization in ThisBuild := Some("streetcontxt")
+
+resolvers in ThisBuild += Resolver.bintrayRepo("streetcontxt", "maven")
+
+name := "kcl-akka-stream"
+
+val versionPattern = "release-([0-9\\.]*)".r
+version := sys.props
+  .get("CIRCLE_TAG")
+  .orElse(sys.env.get("CIRCLE_TAG"))
+  .flatMap { 
+    case versionPattern(v) => Some(v)
+    case _ => None
+  }
+  .getOrElse("LOCAL-SNAPSHOT")
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.21"
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
 val amazonKinesisClient = "com.amazonaws" % "amazon-kinesis-client" % "1.8.8"
-val scalaKinesisProducer = "com.contxt" %% "kpl-scala" % "1.0.2-SNAPSHOT"
+val scalaKinesisProducer = "com.contxt" %% "kpl-scala" % "1.0.3"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
 val scalaMock = "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0"
 val akkaStream = "com.typesafe.akka" %% "akka-stream" % "2.5.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
+


### PR DESCRIPTION
* The build uses a version "LOCAL-SNAPSHOT" unless it is a build triggered by a tag named release-x.x.x, in which case it will use the x.x.x portion of the tag name as the version.
* The build attempts to push releases to a bintray organization named streetcontxt, appropriate values for the BINTRAY_USER and BINTRAY_PASS (actually the API key) environment variables should be set in the circleci project.
* Changed the organization to the full com.streetcontxt domain
* updated the kpl dependency to use the latest version published to bintray