### PR TITLE
Merge records instead of batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ and re-sharding capabilities.
 
 This library is thoroughly tested, but still in early stages.
 
+## Usage
+
+```
+resolvers in ThisBuild += Resolver.bintrayRepo("streetcontxt", "maven")
+libraryDependencies += "com.contxt" %% "kcl-akka-stream" % "1.0.4"
+```
 
 ## Amazon Licensing Restrictions
 **KCL license is not compatible with open source licenses!** See

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versionPattern = "release-([0-9\\.]*)".r
 version := sys.props
   .get("CIRCLE_TAG")
   .orElse(sys.env.get("CIRCLE_TAG"))
-  .flatMap { 
+  .flatMap {
     case versionPattern(v) => Some(v)
     case _ => None
   }


### PR DESCRIPTION
This allows better work interleaving and prevents shard starvation in extreme cases.