### PR TITLE
Removed Materializer Argument from Factories

### DIFF
--- a/src/it/scala/com/contxt/kinesis/KinesisSourceTest.scala
+++ b/src/it/scala/com/contxt/kinesis/KinesisSourceTest.scala
@@ -21,7 +21,7 @@ class KinesisSourceTest
   private val log = LoggerFactory.getLogger(getClass)
   implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(Span(120, Seconds)), scaled(Span(4, Seconds)))
   override protected def afterAll: Unit = TestKit.shutdownActorSystem(system)
-  protected implicit val materializer: ActorMaterializer = ActorMaterializer()
+  protected implicit val materializer: Materializer = ActorMaterializer()
 
   private val initialShardCount = 4
   private val halfShardCount = initialShardCount / 2

--- a/src/it/scala/com/contxt/kinesis/KinesisTestComponents.scala
+++ b/src/it/scala/com/contxt/kinesis/KinesisTestComponents.scala
@@ -1,7 +1,7 @@
 package com.contxt.kinesis
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, KillSwitches, ThrottleMode, UniqueKillSwitch }
+import akka.stream._
 import akka.stream.scaladsl.{ Flow, Keep, Merge, RunnableGraph, Sink, Source }
 import org.scalatest.Tag
 import org.scalatest.concurrent.Eventually._
@@ -14,7 +14,7 @@ trait KinesisTestComponents {
 
   type KeyAndMessage = (String, String)
   protected implicit val patienceConfig: PatienceConfig
-  protected implicit val materializer: ActorMaterializer
+  protected implicit val materializer: Materializer
 
   protected val bootstrapKeyPrefix = "bootstrap"
 

--- a/src/main/scala/com/contxt/kinesis/MaterializerAsValue.scala
+++ b/src/main/scala/com/contxt/kinesis/MaterializerAsValue.scala
@@ -1,0 +1,35 @@
+package com.contxt.kinesis
+
+import akka.stream._
+import akka.stream.scaladsl._
+import akka.stream.stage._
+import scala.concurrent.{ Future, Promise }
+
+private[kinesis] object MaterializerAsValue {
+  /** A source that starts already completed, and provides a future of stream materializer as the materialized value. */
+  def source[In]: Source[In, Future[Materializer]] = {
+    val stage = new GraphStageWithMaterializedValue[SourceShape[In], Future[Materializer]] {
+      val out: Outlet[In] = Outlet("MaterializerAsValueSource.out")
+      val shape: SourceShape[In] = SourceShape(out)
+
+      def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Materializer]) = {
+        val promise = Promise[Materializer]
+        val logic = new GraphStageLogic(shape) {
+          override def preStart(): Unit = {
+            promise.trySuccess(materializer)
+            completeStage()
+          }
+
+          setHandler(out, new OutHandler {
+            override def onPull(): Unit = {
+              // Do nothing.
+            }
+          })
+        }
+        val materializedValue = promise.future
+        (logic, materializedValue)
+      }
+    }
+    Source.fromGraph(stage)
+  }
+}

--- a/src/test/scala/com/contxt/kinesis/KinesisSourceFactoryTest.scala
+++ b/src/test/scala/com/contxt/kinesis/KinesisSourceFactoryTest.scala
@@ -2,7 +2,7 @@ package com.contxt.kinesis
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, KillSwitches, UniqueKillSwitch }
+import akka.stream.{ ActorMaterializer, KillSwitches, Materializer, UniqueKillSwitch }
 import akka.stream.scaladsl.{ Keep, Sink, Source }
 import akka.testkit.TestKit
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
@@ -19,7 +19,7 @@ class KinesisSourceFactoryTest
   with WordSpecLike with BeforeAndAfterAll with Matchers with Eventually
 {
   override protected def afterAll: Unit = TestKit.shutdownActorSystem(system)
-  protected implicit val materializer: ActorMaterializer = ActorMaterializer()
+  protected implicit val materializer: Materializer = ActorMaterializer()
   private val awaitDuration = 5.seconds
 
   "KinesisSource" when {

--- a/src/test/scala/com/contxt/kinesis/MaterializerAsValueTest.scala
+++ b/src/test/scala/com/contxt/kinesis/MaterializerAsValueTest.scala
@@ -1,0 +1,34 @@
+package com.contxt.kinesis
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Sink
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.testkit.TestKit
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class MaterializerAsValueTest
+  extends TestKit(ActorSystem("TestSystem"))
+  with WordSpecLike with BeforeAndAfterAll with Matchers
+{
+  override protected def afterAll: Unit = TestKit.shutdownActorSystem(system)
+  protected implicit val materializer: Materializer = ActorMaterializer()
+  private val awaitTimeout = 1.second
+
+  "MaterializerAsValue" when {
+    "materialized" should {
+      "start already completed" in {
+        val resultFuture = MaterializerAsValue.source[Int].runWith(Sink.seq)
+        val result = Await.result(resultFuture, awaitTimeout)
+        result shouldBe empty
+      }
+
+      "return a future of materializer as the materialized value" in {
+        val materializerFuture = MaterializerAsValue.source[Int].to(Sink.seq).run
+        val liftedMaterializer = Await.result(materializerFuture, awaitTimeout)
+        liftedMaterializer shouldBe materializer
+      }
+    }
+  }
+}


### PR DESCRIPTION
With materializer removed as an explicit argument, we should be able to create immutable sources that can be materialized multiple times.

We get rid of the explicit materializer argument by lifting it into a materialized future, returned by a custom graph stage.

This change renders the public API incompatible with previous versions, and should result in a noticeable version bump. But since the project is still in early stages, I think a minor bump should suffice.