### PR TITLE
Upgrade amazon-kinesis-client to 1.9.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ version := sys.props
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.21"
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
-val amazonKinesisClient = "com.amazonaws" % "amazon-kinesis-client" % "1.8.8"
+val amazonKinesisClient = "com.amazonaws" % "amazon-kinesis-client" % "1.9.3"
 val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "1.0.5"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
 val scalaMock = "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0"


### PR DESCRIPTION
Upgrades amazon-kinesis-client to 1.9.3 - seems to pass testing.

A concise version of the changelog is available at https://github.com/awslabs/amazon-kinesis-client/releases

Personally just doing this to get a fix for awslabs/amazon-kinesis-client#48

Might need to note that the library will now make use of `ListShards` (for the purposes of restrictive IAM policies). For Kinesalite support, people will need 1.13.0 (mhart/kinesalite#59)