### PR TITLE
Configuration update

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,35 @@ eventually causing the system to run out of memory.
 ## Consumer Configuration
 The Kinesis Consumer `ConsumerConfig` can be configured via HOCON configuration, which is common for Akka projects
 ```hocon
-kinesis-consumer {
-  application-name = "test-app" # name of the application (consumer group)
-  stream-name = "test-stream" # name of the stream to connect to
+com.contxt.kinesis {
+  consumer {
+    application-name = "test-app" # name of the application (consumer group)
+    stream-name = "test-stream" # name of the stream to connect to
 
-  position {
-    initial = "latest" # (latest, trim-horizon, at-timestamp). defaults to latest
-    time = "" # Only set if position is at-timestamp. Supports a valid Java Date parseable datetime string
+    position {
+      initial = "latest" # (latest, trim-horizon, at-timestamp) Defaults to latest.
+      # time = "" # Only required if position is at-timestamp. Supports a valid Java Date parseable datetime string
+    }
+
+    # Note: Configurations below need to be in this location (com.contxt.kinesis.consumer) to be found
+
+    # Optional stats reporting class that implements com.contxt.kinesis.ConsumerStats.
+    # stats-class-name = "com.contxt.kinesis.NoopConsumerStats" 
+
+    # Optional checkpoint configuration
+    # shard-checkpoint-config {
+    #   checkpoint-period = 60 seconds
+    #   checkpoint-after-processing-nr-of-records = 10000
+    #   max-wait-for-completion-on-stream-shutdown = 5 seconds
+    # }
   }
 }
+
 ```
 
-Then configuring the consumer using `ConsumerConfig.fromConfig`.
+Then configure the consumer using the convenience method `ConsumerConfig.fromConfig`.
 ```scala
-ConsumerConfig.fromConfig(system.settings.config.getConfig("kinesis-consumer"))
+ConsumerConfig.fromConfig(system.settings.config.getConfig("com.contxt.kinesis.consumer"))
 ```
 
 The `ConsumerConfig` class also has methods for accepting raw AWS SDK clients which can be configured. 

--- a/README.md
+++ b/README.md
@@ -120,23 +120,22 @@ com.contxt.kinesis {
 
     position {
       initial = "latest" # (latest, trim-horizon, at-timestamp) Defaults to latest.
-      # time = "" # Only required if position is at-timestamp. Supports a valid Java Date parseable datetime string
+      time = "" # Only required if position is at-timestamp. Supports a valid Java Date parseable datetime string
     }
 
     # Note: Configurations below need to be in this location (com.contxt.kinesis.consumer) to be found
 
-    # Optional stats reporting class that implements com.contxt.kinesis.ConsumerStats.
-    # stats-class-name = "com.contxt.kinesis.NoopConsumerStats" 
+    # Optional stats reporting class that implements com.contxt.kinesis.ConsumerStats
+    stats-class-name = "com.contxt.kinesis.NoopConsumerStats" 
 
     # Optional checkpoint configuration
-    # shard-checkpoint-config {
-    #   checkpoint-period = 60 seconds
-    #   checkpoint-after-processing-nr-of-records = 10000
-    #   max-wait-for-completion-on-stream-shutdown = 5 seconds
-    # }
+    shard-checkpoint-config {
+      checkpoint-period = 60 seconds
+      checkpoint-after-processing-nr-of-records = 10000
+      max-wait-for-completion-on-stream-shutdown = 5 seconds
+    }
   }
 }
-
 ```
 
 Then configure the consumer using the convenience method `ConsumerConfig.fromConfig`.

--- a/src/it/scala/com/contxt/kinesis/TestStreamConfig.scala
+++ b/src/it/scala/com/contxt/kinesis/TestStreamConfig.scala
@@ -39,9 +39,6 @@ case class TestStreamConfig(
       streamName,
       applicationName,
       workerId,
-      kinesisClient,
-      DynamoDbAsyncClient.builder.region(Region.of(regionName)).build(),
-      CloudWatchAsyncClient.builder.region(Region.of(regionName)).build(),
       initialPositionInStream,
       coordinatorConfig = Some(
         new CoordinatorConfig(applicationName)
@@ -52,6 +49,10 @@ case class TestStreamConfig(
           .retrievalSpecificConfig(new PollingConfig(streamName, kinesisClient))
           .initialPositionInStreamExtended(initialPositionInStream)
       )
+    )(
+      kinesisClient,
+      DynamoDbAsyncClient.builder.region(Region.of(regionName)).build(),
+      CloudWatchAsyncClient.builder.region(Region.of(regionName)).build()
     )
   }
 

--- a/src/main/scala/com/contxt/kinesis/KinesisRecord.scala
+++ b/src/main/scala/com/contxt/kinesis/KinesisRecord.scala
@@ -32,7 +32,8 @@ case class KinesisRecord(
     * records out of order in an asynchronous fashion. Each record must be eventually marked as processed by
     * calling `markProcessed()`, or the steam must be terminated with an exception. If the stream continues
     * after failing to process a record, and not marking it as processed, then no further records can be checkpointed,
-    * eventually causing the system to run out of memory. */
+    * eventually causing the system to run out of memory.
+    */
   def markProcessed(): Unit = completionPromise.trySuccess(Done)
 
   private[kinesis] def offsetString: String = {

--- a/src/main/scala/com/contxt/kinesis/KinesisSource.scala
+++ b/src/main/scala/com/contxt/kinesis/KinesisSource.scala
@@ -40,7 +40,8 @@ import scala.util.control.NonFatal
 object KinesisSource {
 
   /** Creates a Source backed by Kinesis Consumer Library, with materialized valued of Future[Done] which completes
-    * when the stream has terminated and the Kinesis worker has fully shutdown. */
+    * when the stream has terminated and the Kinesis worker has fully shutdown.
+    */
   def apply(kclConfig: ConsumerConfig, config: Config = ConfigFactory.load()): Source[KinesisRecord, Future[Done]] = {
     val shardCheckpointConfig = ShardCheckpointConfig(config)
     val consumerStats = ConsumerStats.getInstance(config)
@@ -48,7 +49,8 @@ object KinesisSource {
   }
 
   /** Creates a Source backed by Kinesis Consumer Library, with materialized valued of Future[Done] which completes
-    * when the stream has terminated and the Kinesis worker has fully shutdown. */
+    * when the stream has terminated and the Kinesis worker has fully shutdown.
+    */
   def apply(
       kclConfig: ConsumerConfig,
       shardCheckpointConfig: ShardCheckpointConfig,

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,10 @@
+com.contxt.kinesis {
+  consumer {
+    application-name = "unit-test-app"
+    stream-name = "unit-test-stream"
+
+    position {
+      initial = "trim-horizon"
+    }
+  }
+}

--- a/src/test/scala/com/contxt/kinesis/ConfigTest.scala
+++ b/src/test/scala/com/contxt/kinesis/ConfigTest.scala
@@ -1,0 +1,70 @@
+package com.contxt.kinesis
+
+import com.typesafe.config.ConfigFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
+import software.amazon.kinesis.common.InitialPositionInStream
+
+class ConfigTest extends AnyWordSpec with Matchers with MockFactory {
+
+  "ConsumerConfig" should {
+
+    "Support minimal configuration with default clients" in {
+      def consumerConfig =
+        ConsumerConfig(
+          streamName = "streamName",
+          appName = "applicationName"
+        )
+
+      consumerConfig.kinesisClient shouldNot be(null)
+      consumerConfig.dynamoClient shouldNot be(null)
+      consumerConfig.cloudwatchClient shouldNot be(null)
+    }
+
+    "Use implicit clients" in {
+      implicit val kinesis: KinesisAsyncClient = mock[KinesisAsyncClient]
+      implicit val dynamo: DynamoDbAsyncClient = mock[DynamoDbAsyncClient]
+      implicit val cloudwatch: CloudWatchAsyncClient = mock[CloudWatchAsyncClient]
+
+      def consumerConfig =
+        ConsumerConfig(
+          streamName = "streamName",
+          appName = "applicationName"
+        )
+
+      assert(consumerConfig.kinesisClient.eq(kinesis))
+      assert(consumerConfig.dynamoClient.eq(dynamo))
+      assert(consumerConfig.cloudwatchClient.eq(cloudwatch))
+    }
+
+    "Read HOCON configuration" in {
+      val config =
+        ConfigFactory
+          .load()
+          .getConfig(
+            "com.contxt.kinesis.consumer"
+          )
+
+      // verify fromConfig also accepts implicits
+      implicit val kinesis: KinesisAsyncClient = mock[KinesisAsyncClient]
+      implicit val dynamo: DynamoDbAsyncClient = mock[DynamoDbAsyncClient]
+      implicit val cloudwatch: CloudWatchAsyncClient = mock[CloudWatchAsyncClient]
+
+      val consumerConfig = ConsumerConfig.fromConfig(config)
+
+      consumerConfig.streamName shouldBe "unit-test-stream"
+      consumerConfig.appName shouldBe "unit-test-app"
+      consumerConfig.initialPositionInStreamExtended.getInitialPositionInStream shouldBe InitialPositionInStream.TRIM_HORIZON
+
+      assert(consumerConfig.kinesisClient.eq(kinesis))
+      assert(consumerConfig.dynamoClient.eq(dynamo))
+      assert(consumerConfig.cloudwatchClient.eq(cloudwatch))
+    }
+
+  }
+
+}

--- a/src/test/scala/com/contxt/kinesis/ConfigTest.scala
+++ b/src/test/scala/com/contxt/kinesis/ConfigTest.scala
@@ -13,18 +13,6 @@ class ConfigTest extends AnyWordSpec with Matchers with MockFactory {
 
   "ConsumerConfig" should {
 
-    "Support minimal configuration with default clients" in {
-      def consumerConfig =
-        ConsumerConfig(
-          streamName = "streamName",
-          appName = "applicationName"
-        )
-
-      consumerConfig.kinesisClient shouldNot be(null)
-      consumerConfig.dynamoClient shouldNot be(null)
-      consumerConfig.cloudwatchClient shouldNot be(null)
-    }
-
     "Use implicit clients" in {
       implicit val kinesis: KinesisAsyncClient = mock[KinesisAsyncClient]
       implicit val dynamo: DynamoDbAsyncClient = mock[DynamoDbAsyncClient]

--- a/src/test/scala/com/contxt/kinesis/KinesisSourceFactoryTest.scala
+++ b/src/test/scala/com/contxt/kinesis/KinesisSourceFactoryTest.scala
@@ -121,10 +121,11 @@ class KinesisSourceFactoryTest
   )
 
   private def clientConfig =
-    new ConsumerConfig(
+    ConsumerConfig(
       streamName = "streamName1",
       appName = "applicationName1",
-      workerId = "workerId",
+      workerId = "workerId"
+    )(
       kinesisClient = mock[KinesisAsyncClient],
       dynamoClient = mock[DynamoDbAsyncClient],
       cloudwatchClient = mock[CloudWatchAsyncClient]


### PR DESCRIPTION
The uses of this library I've seen in our repos are compatible with the changes in this PR, and wouldn't require any code changes to update. But other users might have to make some _small_ changes, so I'll release this as a new major version.

Changes:

1. There were several different ways to initialize ConsumerConfig, and they behaved differently. E.g. accepting/not accepting implicits, and initializing the default kinesis client using a different method. So you could get unexpected behavior when switching from one method to another. And there were other inconsistencies that were more of a usability issue, e.g. some values could be passed as params, but to set others you needed to use a builder-style copy method. So I changed things around to make them more consistent: (1) Moved all initialization and default logic into only two methods, apply and fromConfig, which behave the same way (both accept implicits, both initialize default clients with the same functions). The only difference is one reads certain values from a config, while the other has those values as params. (2) You can set any ConsumerConfig values using the params of these methods, so we no longer need the "with..." builder-style methods. (3) Moved configuration file reading into a separate object to keep it from getting mixed in with other initialization logic.

2. Changed the example configuration location in the readme (does not change behavior): Older configuration settings weren't added to the readme before, and need to be in a specific location. So some of our configurations ended up with two separate sections for the same consumer: one with the old settings, and one in the location that was copy-pasted from the readme for the new settings. So I just updated the example to include the old configs, and put the new ones in the same section so people won't end up with two different sections. (Two sections will still work, since the new configs can go anywhere and the location is passed manually.)