### PR TITLE
Opt-in for auto-merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ project/project/target/
 .idea
 *.class
 *.log
+
+.bloop
+.metals
+project/metals.sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - "status-success=ci/circleci: test"
       - "#approved-reviews-by>=2"
+      - label=ready-to-merge
     actions:
       merge:
         method: merge
@@ -10,7 +11,7 @@ pull_request_rules:
     conditions:
       - author=github-scx
       - "status-success=ci/circleci: test"
-      - body~=labels:.*semver(-patch|-minor)
+      - body~=labels:.*semver-patch
       - label=dependency
     actions:
       merge:


### PR DESCRIPTION
Updates to Mergify configuration
- allow PRs that have 2 approvals **and** labeled `ready-to-merge` to be auto-merged
- auto-merge only "patch" dependency update PRs.
